### PR TITLE
Add a null check on this.server before calling server.close.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,19 @@ SSHTunnel.prototype.log = function () {
 
 SSHTunnel.prototype.close = function (callback) {
     var self = this;
-    this.server.close(function (error) {
-        self.connection.end();
+    if (!this.server) {
         if (callback) {
-            callback(error);
+            callback();
         }
-    });
+    }
+    else {
+        this.server.close(function (error) {
+            self.connection.end();
+            if (callback) {
+                callback(error);
+            }
+        });
+    }
 };
 
 SSHTunnel.prototype.connect = function (callback) {


### PR DESCRIPTION
I ran into the following error when I tried to call tunnel.close() after there was an error calling tunnel.connect():

    [ERROR] TypeError: Cannot call method 'close' of undefined
        at SSHTunnel.close (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/index.js:22:17)
        at exports.connect (/Users/jarwol/code/node-db-migrate/lib/driver/index.js:72:16)
        at Connection.SSHTunnel.connect (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/index.js:98:9)
        at Connection.emit (events.js:95:17)
        at Connection._tryNextAuth (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Connection.js:982:10)
        at onUSERAUTH_FAILURE (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Connection.js:2360:8)
        at Parser._parser.on.msg (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Connection.js:135:5)
        at Parser.emit (events.js:98:17)
        at Parser.parsePacket (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Parser.js:488:12)
        at Parser.execute (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Parser.js:249:14)
        at Socket.Connection.connect._sock.once.err.level (/Users/jarwol/code/node-db-migrate/node_modules/tunnel-ssh/node_modules/ssh2/lib/Connection.js:523:18)
        at Socket.emit (events.js:95:17)
        at Socket.<anonymous> (_stream_readable.js:764:14)
        at Socket.emit (events.js:92:17)
        at emitReadable_ (_stream_readable.js:426:10)
        at emitReadable (_stream_readable.js:422:5)

My specific use case was an SSH authentication error (inline password not allowed), which results in the Connection object's error handler being executed (line 104 of my pull request).  `this.server` is undefined at this point because of the error during connection, so tunnel.close() fails when it attempts to call close() on the server object.