### PR TITLE
Allow to have config.localPort=0 so local server automatically choose the port

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function createConfig(userConfig) {
         throw new Error('invalid configuration.')
     }
 
-    if (!config.localPort) {
+    if (config.localPort===undefined) {
         config.localPort = config.dstPort;
     }
 


### PR DESCRIPTION
Allow to have config.localPort=0 so local server automatically choose the port. it can be obtain by listening event from localServer :

server.on('netConnection', function (netConnection,server) {
  console.log('listening on port: '+server.address().port)
});