### PR TITLE
Restructure to open the SSH connection only once instead of per in coming connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var net = require('net');
-var debug = require('debug')('tunnel-ssh');
 var Connection = require('ssh2');
 
 var env = process.env;
@@ -26,7 +25,7 @@ function createConfig(userConfig) {
   }
   
   if (!config.dstPort || !config.dstHost || !config.host) {
-    throw new Error('invalid configuration.')
+    throw new Error('invalid configuration.');
   }
   
   if (config.localPort === undefined) {
@@ -38,7 +37,7 @@ function createConfig(userConfig) {
 
 var queue = [];
 var queuingConnectListener = function (netConnection) {
-  queue.push(netConnection)
+  queue.push(netConnection);
 };
 
 function bindSSHConnection(config, server) {
@@ -84,13 +83,17 @@ function tunnel(configArgs, callback) {
   server.on('connection', queuingConnectListener);
 
   server.listen(config.localPort, config.localHost, function (err) {
+    if (err) {
+      return callback(err);
+    }
+
     var sshConnection = bindSSHConnection(config, server);
     sshConnection.connect(config);
     sshConnection.on('close', function () {
       server.close();
     });
 
-    return callback(err);
+    return callback();
   });
 
   return server;

--- a/index.js
+++ b/index.js
@@ -1,73 +1,99 @@
 var net = require('net');
 var debug = require('debug')('tunnel-ssh');
-var _ = require('lodash');
 var Connection = require('ssh2');
 
-function createConfig(userConfig) {
-    var env = process.env;
+var env = process.env;
+var defaults = {
+  username: env.TUNNELSSH_USER || env.USER || env.USERNAME,
+  port: 22,
+  srcPort: 0,
+  srcHost: 'localhost',
+  dstPort: null,
+  dstHost: 'localhost',
+  localHost: 'localhost'
+};
 
-    var config = _.defaults(userConfig || {}, {
-        username: env.TUNNELSSH_USER || env.USER || env.USERNAME,
-        sshPort: 22,
-        srcPort: 0,
-        srcHost: 'localhost',
-        dstPort: null,
-        dstHost: 'localhost',
-        localHost: 'localhost'
-
-    });
-    if (!config.password && !config.privateKey) {
-        config.agent = config.agent || process.env.SSH_AUTH_SOCK;
-    }
-
-    if (!config.dstPort || !config.dstHost || !config.host) {
-        throw new Error('invalid configuration.')
-    }
-
-    if (config.localPort===undefined) {
-        config.localPort = config.dstPort;
-    }
-
-    return config;
+function createConfig(userConfig) {  
+  var config = Object.create(defaults);
+  
+  // override defaults
+  Object.keys(userConfig).forEach(function (key) {
+    config[key] = userConfig[key];
+  });
+  
+  if (!config.password && !config.privateKey) {
+    config.agent = config.agent || process.env.SSH_AUTH_SOCK;
+  }
+  
+  if (!config.dstPort || !config.dstHost || !config.host) {
+    throw new Error('invalid configuration.')
+  }
+  
+  if (config.localPort === undefined) {
+    config.localPort = config.dstPort;
+  }
+  
+  return config;
 }
 
-function bindSSHConnection(config, server, netConnection) {
+var queue = [];
+var queuingConnectListener = function (netConnection) {
+  queue.push(netConnection)
+};
 
-    var sshConnection = new Connection();
-    sshConnection.on('ready', function () {
-        //sshConnection._sock.unref();
-        //server.unref();
-        server.emit('sshConnection', sshConnection, netConnection, server);
-        sshConnection.forwardOut(
-            config.srcHost,
-            config.srcPort,
-            config.dstHost,
-            config.dstPort, function (err, sshStream) {
-                if (err) {
-                    throw err;
-                }
-                sshStream.once('close', function () {
-                    sshConnection.end();
-                    if (!config.keepAlive) {
-                        netConnection.end();
-                        server.close();
-                    }
-                });
-                server.emit('sshStream', sshStream, sshConnection, netConnection, server);
-                netConnection.pipe(sshStream).pipe(netConnection);
-            });
-    });
-    return sshConnection;
+function bindSSHConnection(config, server) {
+  
+  var sshConnection = new Connection();
+  sshConnection.on('ready', function () {
+    server.emit('sshConnection', sshConnection, server);
+    
+    function onConnection(netConnection) {
+      server.emit('netConnection', netConnection, server);
+      
+      sshConnection.forwardOut(
+        config.srcHost,
+                config.srcPort,
+                config.dstHost,
+                config.dstPort, function (err, sshStream) {
+          if (err) {
+            throw err;
+          }
+          sshStream.once('close', function () {
+            if (!config.keepAlive) {
+              netConnection.end();
+            }
+          });
+          server.emit('sshStream', sshStream, sshConnection, netConnection, server);
+          netConnection.pipe(sshStream).pipe(netConnection);
+        });
+    }
+
+    server.on('connection', onConnection);
+    server.removeListener('connection', queuingConnectListener);    
+    queue.forEach(onConnection);
+    queue = [];
+  });
+  return sshConnection;
 }
 
 function tunnel(configArgs, callback) {
-    var config = createConfig(configArgs);
-    var server = net.createServer(function (netConnection) {
-        server.emit('netConnection', netConnection, server);
-        bindSSHConnection(config, server, netConnection).connect(config)
+  var config = createConfig(configArgs);
+  
+  var server = net.createServer();
+  
+  server.on('connection', queuingConnectListener);
+
+  server.listen(config.localPort, config.localHost, function (err) {
+    var sshConnection = bindSSHConnection(config, server);
+    sshConnection.connect(config);
+    sshConnection.on('close', function () {
+      server.close();
     });
-    server.listen(config.localPort, config.localHost, callback);
-    return server;
+
+    return callback(err);
+  });
+
+  return server;
 }
 
 module.exports = tunnel;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "debug": "^2.1.3",
     "ssh2": "^0.4.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "dependencies": {
     "debug": "^2.1.3",
-    "lodash": "^3.5.0",
     "ssh2": "^0.4.8"
   }
 }


### PR DESCRIPTION
1. Restructure to open the SSH connection only once instead of per in coming connection
2. Removed loadash dependency (was only used for default values), replaced with a prototype based defaults.
3. Removed debug module as it was not used.
4. Closing server only when main ssh connection has closed.