### PR TITLE
Change sshConnection emit to allow for catching errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,9 @@ function createConfig(userConfig) {
 function bindSSHConnection(config, server, netConnection) {
 
     var sshConnection = new Connection();
+    server.emit('sshConnection', sshConnection, netConnection, server);
     sshConnection.on('ready', function() {
 
-        server.emit('sshConnection', sshConnection, netConnection, server);
         sshConnection.forwardOut(
             config.srcHost,
             config.srcPort,


### PR DESCRIPTION
There is no ability to catch an authentication error because sshConnection doesn't emit until ready. Moving it out to before ready solves that. If you are worried about backwards compatibility we could create another event.