### PR TITLE
Revert ssh connection event move

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,10 @@ function createConfig(userConfig) {
 function bindSSHConnection(config, server, netConnection) {
 
     var sshConnection = new Connection();
-    server.emit('sshConnection', sshConnection, netConnection, server);
+    server.emit('sshConnectionCreated');
+
     sshConnection.on('ready', function() {
+        server.emit('sshConnection', sshConnection, netConnection, server);
 
         sshConnection.forwardOut(
             config.srcHost,

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ function bindSSHConnection(config, server, netConnection) {
             config.dstHost,
             config.dstPort, function(err, sshStream) {
                 if (err) {
-                    throw err;
+                    server.emit('error', err);
+                    return;
                 }
                 sshStream.once('close', function() {
                     if (!config.keepAlive) {


### PR DESCRIPTION
It looks like moving the sshConnection event before the ready event might cause some issues with the server close handler (though I didn't actually see any issues). This adds a new event after sshConnection creation and moves the sshConnection event back to the sshConnection ready event. This also includes another fix for a thrown error that can't be caught in forwardOut.