### PR TITLE
Catch SSH errors that occur outside of setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ We're happy to introduce "reverse Tunnel"
     });
 ```
 
+####catch SSH errors that occur outside of setup:
+```js
+    var tunnel = require('tunnel-ssh');
+    //map port from remote 3306 to localhost 3306
+    var server = tunnel({host: '172.16.0.8', dstPort: 3306}, function (error, result) {
+        //you can start using your resources here. (mongodb, mysql, ....)
+        console.log('connected');
+    });
+    
+    server.on('error', function(err){
+        console.error('Something bad happened:', err);
+    });
+```
 
 ####Reverse tunnel
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function createServer(config) {
     netConnection.on('error', server.emit.bind(server, 'error'));
     server.emit('netConnection', netConnection, server);
     sshConnection = bindSSHConnection(config, netConnection);
+    sshConnection.on('error', server.emit.bind(server, 'error'));
     netConnection.on('sshStream', function (sshStream) {
       sshStream.once('close', function () {
         debug('sshStream:close');


### PR DESCRIPTION
Before:
```
events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: Timed out while waiting for handshake
    at null._onTimeout (/Users/joshuabalfour/project name/node_modules/ssh2/lib/client.js:567:19)
    at Timer.listOnTimeout (timers.js:92:15)
```

After:
```
var server = tunnel(...);
server.on('error', function(err){
        console.error('got ssh error:', err);
});
```
```
got ssh error: { [Error: Timed out while waiting for handshake] level: 'client-timeout' }
```